### PR TITLE
Fix admin can't create record

### DIFF
--- a/js/components/record/Record.js
+++ b/js/components/record/Record.js
@@ -59,7 +59,7 @@ class Record extends React.Component {
                     {this._showInstitution() && this._renderInstitution()}
                     <RecordProvenance record={record}/>
                 </form>
-                {this._renderForm()}
+                {record.formTemplate && this._renderForm()}
                 {this._renderButtons()}
                 {showAlert && recordSaved.status === ACTION_STATUS.ERROR &&
                 <div>

--- a/js/components/record/RecordForm.js
+++ b/js/components/record/RecordForm.js
@@ -121,7 +121,7 @@ class RecordForm extends React.Component {
             return <AlertMessage
                 type={ALERT_TYPES.DANGER}
                 message={this.props.formatMessage('record.load-form-error', {error: this.props.formgen.error.message})}/>;
-        } else if (this.props.formgen.status === ACTION_STATUS.PENDING || !this.state.form) {
+        } else if (!!this.props.record.formTemplate && (this.props.formgen.status === ACTION_STATUS.PENDING || !this.state.form)) {
             return <Loader/>;
         }
 

--- a/js/components/record/RecordForm.js
+++ b/js/components/record/RecordForm.js
@@ -34,14 +34,16 @@ class RecordForm extends React.Component {
     }
 
     componentDidMount() {
-        this.props.loadFormgen(ACTION_STATUS.PENDING);
-        this.loadWizard();
+        if(this.props.record.formTemplate) {
+            this.props.loadFormgen(ACTION_STATUS.PENDING);
+            this.loadWizard();
+        }
     }
 
     componentDidUpdate(prevProps, prevState, snapshot) {
         const {record} = this.props;
-
-        if (prevProps.record.question?.uri !== record.question?.uri) {
+        if(record.formTemplate && record.formTemplate != prevProps.record.formTemplate) {
+            this.props.loadFormgen(ACTION_STATUS.PENDING);
             this.loadWizard();
         }
     }

--- a/js/components/record/RequiredAttributes.js
+++ b/js/components/record/RequiredAttributes.js
@@ -44,6 +44,7 @@ class RequiredAttributes extends React.Component {
                 <div className='col-11 col-sm-6'>
                     <HorizontalInput
                         labelWidth={4} inputWidth={8}
+                        isDisabled={!!record.formTemplate}
                         type='autocomplete' name='formTemplate' value={record.formTemplate || formTemplate}
                         label={this.i18n('records.form-template') + '*'} onChange={this.props.onChange}
                         possibleValuesEndpoint={possibleValuesEndpoint}

--- a/js/components/record/TypeaheadAnswer.js
+++ b/js/components/record/TypeaheadAnswer.js
@@ -58,7 +58,7 @@ const TypeaheadAnswer = (props) => {
             isSearchable={true}
             isLoading={isLoading}
             isClearable={true}
-            isDisabled={isLoading}
+            isDisabled={isLoading || (props.isDisabled === undefined ? false : props.isDisabled) }
             value={options.filter((option) => option.id === props.value)}
             placeholder={''}
             getOptionLabel={(option) => option.name}

--- a/js/components/record/TypeaheadAnswer.js
+++ b/js/components/record/TypeaheadAnswer.js
@@ -58,7 +58,7 @@ const TypeaheadAnswer = (props) => {
             isSearchable={true}
             isLoading={isLoading}
             isClearable={true}
-            isDisabled={isLoading || (props.isDisabled === undefined ? false : props.isDisabled) }
+            isDisabled={isLoading || (props.isDisabled === true) }
             value={options.filter((option) => option.id === props.value)}
             placeholder={''}
             getOptionLabel={(option) => option.name}
@@ -73,7 +73,8 @@ TypeaheadAnswer.propTypes = {
     possibleValuesEndpoint: PropTypes.string.isRequired,
     label: PropTypes.string.isRequired,
     value: PropTypes.string,
-    onChange: PropTypes.func.isRequired
+    onChange: PropTypes.func.isRequired,
+    isDisabled: PropTypes.bool
 };
 
 export default TypeaheadAnswer;


### PR DESCRIPTION
Fix #25
Solution:
1. on records page admin clicks create record
2. the create/record page is displayed where admin can select the form template
3. after form template is selected the form template field is disabled and the selected form is loaded from the backend
4. The loader component is shown after the selection of the form template and removed after the form is loaded from the backend.