### PR TITLE
Issues/41 load record form in user role

### DIFF
--- a/js/components/record/Record.js
+++ b/js/components/record/Record.js
@@ -64,7 +64,7 @@ class Record extends React.Component {
                     {this._showInstitution() && this._renderInstitution()}
                     <RecordProvenance record={record}/>
                 </form>
-                {record.formTemplate && this._renderForm()}
+                {this._renderForm()}
                 {this._renderButtons()}
                 {showAlert && recordSaved.status === ACTION_STATUS.ERROR &&
                 <div>

--- a/js/components/record/Record.js
+++ b/js/components/record/Record.js
@@ -41,6 +41,11 @@ class Record extends React.Component {
     render() {
         const {recordLoaded, recordSaved, showAlert, record, formTemplate, currentUser} = this.props;
 
+        if (!record?.formTemplate) {
+            if (formTemplate) {
+                record.formTemplate = formTemplate;
+            }
+        }
         if (recordLoaded.status === ACTION_STATUS.ERROR) {
             return <AlertMessage type={ALERT_TYPES.DANGER}
                                  message={this.props.formatMessage('record.load-error', {error: this.props.recordLoaded.error.message})}/>;

--- a/js/components/record/RecordForm.js
+++ b/js/components/record/RecordForm.js
@@ -125,7 +125,7 @@ class RecordForm extends React.Component {
             return <Loader/>;
         }
 
-        return <SForms
+        return !!this.state.form && <SForms
             ref={this.refForm}
             form={this.state.form}
             formData={this.props.record.question}

--- a/js/components/record/RequiredAttributes.js
+++ b/js/components/record/RequiredAttributes.js
@@ -24,16 +24,6 @@ class RequiredAttributes extends React.Component {
         this.i18n = this.props.i18n;
     }
 
-    componentDidMount() {
-        const {record, formTemplate} = this.props;
-
-        if (!record.formTemplate) {
-            if (formTemplate) {
-                record.formTemplate = formTemplate;
-            }
-        }
-    }
-
     render() {
         const {record, formTemplate} = this.props;
         const possibleValuesEndpoint = `${API_URL}/rest/formGen/formTemplates`;


### PR DESCRIPTION
User role was not able to  create record because the form was not loaded. This issue was caused by pull request #33 .

The problem is that #33 renders RecordForm if `record.formTemplate` is defined in the Record.render method. For the admin user role this is not a problem because the value of `record.formTemplate` could be set by the admin selecting the form template from the `form-template` field. 

For the regular user role 
- the `form-template` field is not rendered 
- the form template is passed using a URI query parameter which is propagated as `prop.formTemplate` in Record component. 

The solution is to make sure that `record.formTemplate` is set before rendering RecordForm. 
