### PR TITLE
Empty pagination

### DIFF
--- a/src/components/record/Records.jsx
+++ b/src/components/record/Records.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Button, Card } from "react-bootstrap";
+import { Alert, Button, Card } from "react-bootstrap";
 import { injectIntl } from "react-intl";
 import withI18n from "../../i18n/withI18n";
 import { EXTENSION_CONSTANTS } from "../../constants/DefaultConstants";
@@ -70,12 +70,15 @@ class Records extends React.Component {
           {this._getPanelTitle()}
         </Card.Header>
         <Card.Body>
-          {recordsLoaded.records && (
+          {recordsLoaded.records && recordsLoaded.records.length > 0 ? (
             <>
               <RecordTable {...this.props} />
               <Pagination {...pagination} />
             </>
+          ) : (
+            <Alert variant="warning">No records</Alert>
           )}
+
           <ImportRecordsDialog
             show={this.state.showImportDialog}
             onSubmit={this.onImport}


### PR DESCRIPTION
Resolves #171

If there are no records, the table will not be shown, as it is unnecessary.

![pagination_warnging](https://github.com/user-attachments/assets/9557ef59-2340-4f42-9b50-ff1ecfdcbe61)

When there are records, the table behaves as before.
![non-empty-records](https://github.com/user-attachments/assets/a00320e9-a47c-43ee-971f-793a0e244044)
