### PR TITLE
Show add new user button only in internal profile

### DIFF
--- a/src/components/institution/InstitutionMembers.jsx
+++ b/src/components/institution/InstitutionMembers.jsx
@@ -8,6 +8,7 @@ import Loader, { LoaderSmall } from "../Loader";
 import PropTypes from "prop-types";
 import { isAdmin } from "../../utils/SecurityUtils";
 import PromiseTrackingMask from "../misc/PromiseTrackingMask";
+import IfInternalAuth from "../misc/oidc/IfInternalAuth.jsx";
 
 class InstitutionMembers extends React.Component {
   constructor(props) {
@@ -75,13 +76,15 @@ class InstitutionMembers extends React.Component {
           ) : (
             <p className="font-italic">{this.i18n("institution.members.not-found")}</p>
           )}
-          {isAdmin(currentUser) && (
-            <div className="btn-toolbar">
-              <Button variant="primary" size="sm" onClick={() => onAddNewUser(institution)}>
-                {this.i18n("users.add-new-user")}
-              </Button>
-            </div>
-          )}
+          <IfInternalAuth>
+            {isAdmin(currentUser) && (
+              <div className="btn-toolbar">
+                <Button variant="primary" size="sm" onClick={() => onAddNewUser(institution)}>
+                  {this.i18n("users.add-new-user")}
+                </Button>
+              </div>
+            )}
+          </IfInternalAuth>
         </Card.Body>
       </Card>
     );


### PR DESCRIPTION
Resolves #176

I think it makes sense to show it only in the internal profile because we don't create users via the application in the Keycloak profile

In keycloak profile now:
![keycloak_strange_add_user](https://github.com/user-attachments/assets/6804c84f-07c8-47a9-ba40-5b32cd7ffb5d)

