### PR TITLE
[#334] Migrate dc/elements/1.1/ to dc/terms/

### DIFF
--- a/deploy/shared/db-server/import/record-manager-formgen/example-1-v0.0.1-form.trig
+++ b/deploy/shared/db-server/import/record-manager-formgen/example-1-v0.0.1-form.trig
@@ -1,4 +1,3 @@
-@prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix doc: <http://onto.fel.cvut.cz/ontologies/documentation/> .
 @prefix ex1: <https://example.org/sfc-example-1/> .
@@ -52,7 +51,7 @@
       form:has-identifying-question "test-5279" ;
       form:has-preceding-question ex1:non-answerable-section-with-advanced-switch ;
       form:has-question-origin ex1:answerable-section-with-advanced-switch-qo ;
-      dc:source <https://slovník.gov.cz/generický/množství/pojem/má-jednotku> .
+      dcterms:source <https://slovník.gov.cz/generický/množství/pojem/má-jednotku> .
 
   ex1:first-name-9402 a doc:question ;
       rdfs:label "Jméno" ;
@@ -173,7 +172,7 @@
       form-lt:has-layout-class "text" ;
       form:has-question-origin ex1:ps-cin-452-qo ;
       form:is-relevant-if ex1:provozovatel-pravnicka-osoba-condition ;
-      dc:description "Company identification number" .
+      dcterms:description "Company identification number" .
 
   ex1:ps-iq-452 a doc:question ;
       rdfs:label "IQ" ;
@@ -227,13 +226,13 @@
       rdfs:label "Field test" ;
       form-lt:has-layout-class "text" ;
       form:has-question-origin ex1:test-field-3888-qo ;
-      dc:source <https://slovník.gov.cz/generický/množství/pojem/má-jednotku> .
+      dcterms:source <https://slovník.gov.cz/generický/množství/pojem/má-jednotku> .
 
   ex1:test-field-3888-na a doc:question ;
       rdfs:label "Field test" ;
       form-lt:has-layout-class "text" ;
       form:has-question-origin ex1:test-field-3888-na-qo ;
-      dc:source <https://slovník.gov.cz/generický/množství/pojem/má-jednotku> .
+      dcterms:source <https://slovník.gov.cz/generický/množství/pojem/má-jednotku> .
 
   ex1:age-1063 a doc:question ;
       rdfs:label "Age" ;
@@ -250,7 +249,7 @@
       form:has-preceding-question ex1:age-1063 ;
       form:has-question-origin ex1:cena-6557-qo ;
       form:has-unit-of-measure-question "mena-8088" ;
-      dc:description "Tohle je cena s měnou" .
+      dcterms:description "Tohle je cena s měnou" .
 
   ex1:non-answerable-section-with-advanced-switch a doc:question ;
       rdfs:label "Simple section with advanced switch" ;
@@ -263,7 +262,7 @@
       form:has-identifying-question "test-5279-na" ;
       form:has-preceding-question ex1:test-section-666 ;
       form:has-question-origin ex1:non-answerable-section-with-advanced-switch-qo ;
-      dc:source <https://slovník.gov.cz/generický/množství/pojem/má-jednotku> .
+      dcterms:source <https://slovník.gov.cz/generický/množství/pojem/má-jednotku> .
 
   ex1:parent-section-1590 a doc:question ;
       rdfs:label "Vlastník" ;
@@ -309,7 +308,7 @@
               form:has-timestamp "1636061441831" ] ;
       form:has-question-origin ex1:form-show-advanced-question ;
       form:show-advanced-question true ;
-      dc:description "Advanced switch test" .
+      dcterms:description "Advanced switch test" .
 
   ex1:show-advanced-question-test-advanced-switch-na a doc:question ;
       rdfs:label "Advanced switch test" ;
@@ -324,7 +323,7 @@
               form:has-timestamp "1636065441831" ] ;
       form:has-question-origin ex1:form-show-advanced-question ;
       form:show-advanced-question true ;
-      dc:description "Advanced switch test" .
+      dcterms:description "Advanced switch test" .
 
   ex1:test-section-666 a doc:question ;
       rdfs:label "Sekce s identifikátorem" ;
@@ -335,7 +334,7 @@
       form:has-identifying-question "test-5278" ;
       form:has-preceding-question ex1:parent-section-1590 ;
       form:has-question-origin ex1:test-section-666-qo ;
-      dc:description "test" .
+      dcterms:description "test" .
 
   ex1:title-7183 a doc:question ;
       rdfs:label "Titul" ;

--- a/deploy/shared/db-server/import/record-manager-formgen/forms/example-1-form.ttl
+++ b/deploy/shared/db-server/import/record-manager-formgen/forms/example-1-form.ttl
@@ -1,4 +1,3 @@
-@prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix doc: <http://onto.fel.cvut.cz/ontologies/documentation/> .
 @prefix ex1: <https://example.org/sfc-example-1/> .
@@ -14,7 +13,7 @@ ex1:form-root a doc:question ;
     a form:form-template ;
     dcterms:hasVersion <https://example.org/sfc-example-1/form-root/0.0.2> ;
     rdfs:label "Form example 1" ;
-    rdfs:comment "First example of a form" ;
+    dcterms:description "First example of a form" ;
     doc:has_related_question ex1:age-1063,
         ex1:answerable-section-with-advanced-switch,
         ex1:cena-6557,
@@ -49,7 +48,7 @@ ex1:answerable-section-with-advanced-switch a doc:question ;
     form:has-identifying-question "test-5279" ;
     form:has-preceding-question ex1:non-answerable-section-with-advanced-switch ;
     form:has-question-origin ex1:answerable-section-with-advanced-switch-qo ;
-    dc:source <https://slovník.gov.cz/generický/množství/pojem/má-jednotku> .
+    dcterms:source <https://slovník.gov.cz/generický/množství/pojem/má-jednotku> .
 
 ex1:first-name-9402 a doc:question ;
     rdfs:label "Jméno" ;
@@ -170,7 +169,7 @@ ex1:ps-cin-452 a doc:question ;
     form-lt:has-layout-class "text" ;
     form:has-question-origin ex1:ps-cin-452-qo ;
     form:is-relevant-if ex1:provozovatel-pravnicka-osoba-condition ;
-    dc:description "Company identification number" .
+    dcterms:description "Company identification number" .
 
 ex1:ps-iq-452 a doc:question ;
     rdfs:label "IQ" ;
@@ -225,13 +224,13 @@ ex1:test-field-3888 a doc:question ;
     rdfs:label "Field test" ;
     form-lt:has-layout-class "text" ;
     form:has-question-origin ex1:test-field-3888-qo ;
-    dc:source <https://slovník.gov.cz/generický/množství/pojem/má-jednotku> .
+    dcterms:source <https://slovník.gov.cz/generický/množství/pojem/má-jednotku> .
 
 ex1:test-field-3888-na a doc:question ;
     rdfs:label "Field test" ;
     form-lt:has-layout-class "text" ;
     form:has-question-origin ex1:test-field-3888-na-qo ;
-    dc:source <https://slovník.gov.cz/generický/množství/pojem/má-jednotku> .
+    dcterms:source <https://slovník.gov.cz/generický/množství/pojem/má-jednotku> .
 
 ex1:age-1063 a doc:question ;
     rdfs:label "Age" ;
@@ -248,7 +247,7 @@ ex1:cena-6557 a doc:question ;
     form:has-preceding-question ex1:age-1063 ;
     form:has-question-origin ex1:cena-6557-qo ;
     form:has-unit-of-measure-question "mena-8088" ;
-    dc:description "Tohle je cena s měnou" .
+    dcterms:description "Tohle je cena s měnou" .
 
 ex1:non-answerable-section-with-advanced-switch a doc:question ;
     rdfs:label "Simple section with advanced switch" ;
@@ -261,7 +260,7 @@ ex1:non-answerable-section-with-advanced-switch a doc:question ;
     form:has-identifying-question "test-5279-na" ;
     form:has-preceding-question ex1:test-section-666 ;
     form:has-question-origin ex1:non-answerable-section-with-advanced-switch-qo ;
-    dc:source <https://slovník.gov.cz/generický/množství/pojem/má-jednotku> .
+    dcterms:source <https://slovník.gov.cz/generický/množství/pojem/má-jednotku> .
 
 ex1:parent-section-1590 a doc:question ;
     rdfs:label "Vlastník" ;
@@ -308,7 +307,7 @@ ex1:show-advanced-question-test-advanced-switch a doc:question ;
             form:has-timestamp "1636061441831" ] ;
     form:has-question-origin ex1:form-show-advanced-question ;
     form:show-advanced-question true ;
-    dc:description "Advanced switch test" .
+    dcterms:description "Advanced switch test" .
 
 ex1:show-advanced-question-test-advanced-switch-na a doc:question ;
     rdfs:label "Advanced switch test" ;
@@ -323,7 +322,7 @@ ex1:show-advanced-question-test-advanced-switch-na a doc:question ;
             form:has-timestamp "1636065441831" ] ;
     form:has-question-origin ex1:form-show-advanced-question ;
     form:show-advanced-question true ;
-    dc:description "Advanced switch test" .
+    dcterms:description "Advanced switch test" .
 
 ex1:test-field-3887 a doc:question ;
     rdfs:label "Popis vlastníka" ;
@@ -339,7 +338,7 @@ ex1:test-section-666 a doc:question ;
     form:has-identifying-question "test-5278" ;
     form:has-preceding-question ex1:parent-section-1590 ;
     form:has-question-origin ex1:test-section-666-qo ;
-    dc:description "test" .
+    dcterms:description "test" .
 
 ex1:title-7183 a doc:question ;
     rdfs:label "Titul" ;

--- a/deploy/shared/db-server/import/record-manager-formgen/forms/example-2-form.ttl
+++ b/deploy/shared/db-server/import/record-manager-formgen/forms/example-2-form.ttl
@@ -1,4 +1,4 @@
-@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix doc: <http://onto.fel.cvut.cz/ontologies/documentation/> .
 @prefix ex2: <https://example.org/sfc-example-2/> .
 @prefix form: <http://onto.fel.cvut.cz/ontologies/form/> .
@@ -18,7 +18,7 @@ ex2:as-show-advanced-888 a doc:question ;
 ex2:form-root a doc:question ;
     a form:form-template ;
     rdfs:label "Form example 2" ;
-    rdfs:comment "Second example of a form" ;
+    dcterms:description "Second example of a form" ;
     doc:has_related_question ex2:age-1063,
         ex2:answerable-section-with-advanced-switch,
         ex2:cena-6557,
@@ -53,7 +53,7 @@ ex2:answerable-section-with-advanced-switch a doc:question ;
     form:has-identifying-question "test-5279" ;
     form:has-preceding-question ex2:non-answerable-section-with-advanced-switch ;
     form:has-question-origin ex2:answerable-section-with-advanced-switch-qo ;
-    dc:source <https://slovník.gov.cz/generický/množství/pojem/má-jednotku> .
+    dcterms:source <https://slovník.gov.cz/generický/množství/pojem/má-jednotku> .
 
 ex2:first-name-9402 a doc:question ;
     rdfs:label "Jméno" ;
@@ -174,7 +174,7 @@ ex2:ps-cin-452 a doc:question ;
     form-lt:has-layout-class "text" ;
     form:has-question-origin ex2:ps-cin-452-qo ;
     form:is-relevant-if ex2:provozovatel-pravnicka-osoba-condition ;
-    dc:description "Company identification number" .
+    dcterms:description "Company identification number" .
 
 ex2:ps-iq-452 a doc:question ;
     rdfs:label "IQ" ;
@@ -229,13 +229,13 @@ ex2:test-field-3888 a doc:question ;
     rdfs:label "Field test" ;
     form-lt:has-layout-class "text" ;
     form:has-question-origin ex2:test-field-3888-qo ;
-    dc:source <https://slovník.gov.cz/generický/množství/pojem/má-jednotku> .
+    dcterms:source <https://slovník.gov.cz/generický/množství/pojem/má-jednotku> .
 
 ex2:test-field-3888-na a doc:question ;
     rdfs:label "Field test" ;
     form-lt:has-layout-class "text" ;
     form:has-question-origin ex2:test-field-3888-na-qo ;
-    dc:source <https://slovník.gov.cz/generický/množství/pojem/má-jednotku> .
+    dcterms:source <https://slovník.gov.cz/generický/množství/pojem/má-jednotku> .
 
 ex2:age-1063 a doc:question ;
     rdfs:label "Age" ;
@@ -252,7 +252,7 @@ ex2:cena-6557 a doc:question ;
     form:has-preceding-question ex2:age-1063 ;
     form:has-question-origin ex2:cena-6557-qo ;
     form:has-unit-of-measure-question "mena-8088" ;
-    dc:description "Tohle je cena s měnou" .
+    dcterms:description "Tohle je cena s měnou" .
 
 ex2:non-answerable-section-with-advanced-switch a doc:question ;
     rdfs:label "Simple section with advanced switch" ;
@@ -265,7 +265,7 @@ ex2:non-answerable-section-with-advanced-switch a doc:question ;
     form:has-identifying-question "test-5279-na" ;
     form:has-preceding-question ex2:test-section-666 ;
     form:has-question-origin ex2:non-answerable-section-with-advanced-switch-qo ;
-    dc:source <https://slovník.gov.cz/generický/množství/pojem/má-jednotku> .
+    dcterms:source <https://slovník.gov.cz/generický/množství/pojem/má-jednotku> .
 
 ex2:parent-section-1590 a doc:question ;
     rdfs:label "Vlastník" ;
@@ -312,7 +312,7 @@ ex2:show-advanced-question-test-advanced-switch a doc:question ;
             form:has-timestamp "1636061441831" ] ;
     form:has-question-origin ex2:form-show-advanced-question ;
     form:show-advanced-question true ;
-    dc:description "Advanced switch test" .
+    dcterms:description "Advanced switch test" .
 
 ex2:show-advanced-question-test-advanced-switch-na a doc:question ;
     rdfs:label "Advanced switch test" ;
@@ -327,7 +327,7 @@ ex2:show-advanced-question-test-advanced-switch-na a doc:question ;
             form:has-timestamp "1636065441831" ] ;
     form:has-question-origin ex2:form-show-advanced-question ;
     form:show-advanced-question true ;
-    dc:description "Advanced switch test" .
+    dcterms:description "Advanced switch test" .
 
 ex2:test-field-3887 a doc:question ;
     rdfs:label "Popis vlastníka" ;
@@ -343,7 +343,7 @@ ex2:test-section-666 a doc:question ;
     form:has-identifying-question "test-5278" ;
     form:has-preceding-question ex2:parent-section-1590 ;
     form:has-question-origin ex2:test-section-666-qo ;
-    dc:description "test" .
+    dcterms:description "test" .
 
 ex2:title-7183 a doc:question ;
     rdfs:label "Titul" ;

--- a/deploy/shared/db-server/import/record-manager-formgen/forms/shapes/form-template.shapes.ttl
+++ b/deploy/shared/db-server/import/record-manager-formgen/forms/shapes/form-template.shapes.ttl
@@ -7,7 +7,7 @@
 #   2. it is typed form:form-template
 #      (http://onto.fel.cvut.cz/ontologies/form/form-template);
 #   3. it has an rdfs:label;
-#   4. it has an rdfs:comment.
+#   4. it has a dcterms:description.
 #
 # This shape enforces requirements (2)-(4) — the triple-level pattern.
 # Requirement (1), the named-graph constraint, cannot be expressed in core SHACL
@@ -16,6 +16,7 @@
 
 @prefix sh:   <http://www.w3.org/ns/shacl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix form: <http://onto.fel.cvut.cz/ontologies/form/> .
 
 form:FormTemplateShape
@@ -31,7 +32,7 @@ form:FormTemplateShape
         sh:message  "A form template must have at least one rdfs:label; otherwise it is silently dropped from the form template listing." ;
     ] ;
     sh:property [
-        sh:path     rdfs:comment ;
+        sh:path     dcterms:description ;
         sh:minCount 1 ;
-        sh:message  "A form template must have at least one rdfs:comment; otherwise it is silently dropped from the form template listing." ;
+        sh:message  "A form template must have at least one dcterms:description; otherwise it is silently dropped from the form template listing." ;
     ] .

--- a/deploy/shared/db-server/import/record-manager-formgen/migration/dc-to-dcterms.ru
+++ b/deploy/shared/db-server/import/record-manager-formgen/migration/dc-to-dcterms.ru
@@ -1,0 +1,24 @@
+PREFIX dc: <http://purl.org/dc/elements/1.1/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+
+# Migrate dc:description / dc:source to dcterms:description / dcterms:source
+# in named graphs.
+DELETE {
+  GRAPH ?g {
+    ?s ?oldP ?o .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?s ?newP ?o .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?s ?oldP ?o .
+  }
+  VALUES (?oldP ?newP) {
+    (dc:description dcterms:description)
+    (dc:source dcterms:source)
+  }
+}


### PR DESCRIPTION
Resolves partially #334

Migrates the Dublin Core *elements* namespace (`http://purl.org/dc/elements/1.1/`) to DC *Terms* (`http://purl.org/dc/terms/`) for the `description` and `source` properties (the only two `dc:` properties in use).

## Changes
- Updated `@prefix` declarations from `dc:` to `dcterms:` and rewrote `dc:description` → `dcterms:description` and `dc:source` → `dcterms:source` in the form / possible-values source files under `deploy/shared/db-server/import/record-manager-formgen/`.
- Added a SPARQL update migration script `migration/dc-to-dcterms.ru` to migrate existing triplestore data, covering named graphs.